### PR TITLE
Comment git plugin hook for "get_reference"

### DIFF
--- a/plugins/git/include/gitPlugin.class.php
+++ b/plugins/git/include/gitPlugin.class.php
@@ -158,7 +158,7 @@ class GitPlugin extends Plugin
         $this->addHook(Event::GET_SYSTEM_EVENT_CLASS,                     'getSystemEventClass',                          false);
         $this->addHook(Event::GET_PLUGINS_AVAILABLE_KEYWORDS_REFERENCES,  'getReferenceKeywords',                         false);
         $this->addHook(Event::GET_AVAILABLE_REFERENCE_NATURE,             'getReferenceNatures',                          false);
-        $this->addHook(Event::GET_REFERENCE);
+        // $this->addHook(Event::GET_REFERENCE);
         $this->addHook('SystemEvent_PROJECT_IS_PRIVATE',                  'changeProjectRepositoriesAccess',              false);
         $this->addHook('SystemEvent_PROJECT_RENAME',                      'systemEventProjectRename',                     false);
         $this->addHook('project_is_deleted',                              'project_is_deleted',                           false);


### PR DESCRIPTION
Comment hook for "get_reference" so that:
1- git references `git #repo/commit` follow normal path
2- git references obey customizable reference patterns
3- customized git reference patterns can point to external services/sites (e.g., Gitlab)